### PR TITLE
add setups before installing fluentd.

### DIFF
--- a/roles/td-agent/tasks/main.yml
+++ b/roles/td-agent/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+  # http://docs.fluentd.org/articles/before-install
+- name: Increase ulimit (need to reboot to work) !! reboot required !!
+  sudo: yes
+  template: src=limits-td.conf dest=/etc/security/limits.d/90-td.conf
+
+  # http://docs.fluentd.org/articles/before-install
+- name: Optimize Network Kernel Parameters
+  sudo: yes
+  template: src=sysctl-td.conf dest=/etc/sysctl.d/90-td.conf
+
+- name: Reflect sysctl configs
+  sudo: yes
+  command: sysctl -p /etc/sysctl.d/90-td.conf
+  ignore_errors: True # docker does not have these parameters.
+
 - name: download td-agent install script
   get_url: url=https://td-toolbelt.herokuapp.com/sh/install-redhat-td-agent2.sh dest=/tmp/install-td-agent.sh
 

--- a/roles/td-agent/templates/limits-td.conf
+++ b/roles/td-agent/templates/limits-td.conf
@@ -1,0 +1,4 @@
+root soft nofile 65536
+root hard nofile 65536
+* soft nofile 65536
+* hard nofile 65536

--- a/roles/td-agent/templates/sysctl-td.conf
+++ b/roles/td-agent/templates/sysctl-td.conf
@@ -1,0 +1,3 @@
+net.ipv4.tcp_tw_recycle = 1
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.ip_local_port_range = 10240    65535


### PR DESCRIPTION
@ogawaso 
http://docs.fluentd.org/articles/before-install
これの内容です。

ntpdは入れてないです。近頃はntpdじゃなくてchronyというのがおしゃれらしくて、AWSのCentOSには入ってたからいいや、ということで省きました。
